### PR TITLE
Poweroff command bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.idea/
 /authorized.json
 /.venv
+/.pytest_cache
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ import time
 from dotenv import load_dotenv
 from telegram import Update
 from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes, MessageHandler, filters, Job, JobQueue
-from watchdog import watchdog_tick, get_players_list
+from watchdog import watchdog_tick, get_players_list, reset_watchdog_state
 from typing import Optional
 
 # Enable logging
@@ -54,8 +54,8 @@ MAINTENANCE_MODE = False
 def check_maintenance(func):
     @wraps(func)
     async def wrapper(update: Update, context: ContextTypes.DEFAULT_TYPE): # type: ignore
-        if MAINTENANCE_MODE and update.effective_user.id != ADMIN_CHAT_ID:
-            await update.message.reply_text("🚧 Сервер на обслуживании. Попробуйте позже.")
+        if MAINTENANCE_MODE:
+            await update.message.reply_text("🚧 Сервер на обслуживании. Попробуйте выполнить запрос позже.")
             return None
         return await func(update, context)
     return wrapper
@@ -66,7 +66,7 @@ last_poweroff_time = 0
 # Время последнего запроса статуса сервера
 last_status_time = 0
 POWERON_COOLDOWN = 20 * 60  # 20 минут в секундах
-POWEROFF_COOLDOWN = 5 * 60 # 5 минут
+POWEROFF_COOLDOWN = 1 * 60 # 1 минута
 STATUS_COOLDOWN = 5  # запрос статуса
 
 watchdog_job: Optional[Job] = None
@@ -181,8 +181,9 @@ async def shutdown_vps():
     active_chats.clear() # сброс активных чатов для уведомлений после выключения сервера
     global last_poweron_time, watchdog_job
     last_poweron_time = now  # предотвращение быстрого запуска VPS после включения
-    # после выключения VPS сбрасываем задачу watchdog
+    # после выключения VPS сбрасываем задачу и состояние watchdog
     watchdog_stop()
+    reset_watchdog_state()
     return await api_request("ShutDownGuestOS")
 
 

--- a/watchdog.py
+++ b/watchdog.py
@@ -5,6 +5,7 @@ import os
 from dotenv import load_dotenv
 from mcstatus import JavaServer
 from typing import Optional
+from dataclasses import dataclass, fields
 
 load_dotenv()
 
@@ -62,61 +63,72 @@ async def check_server_players(server_address: str, port: int):
     else:
         return None
 
-empty_since: Optional[float] = None  # Когда сервер стал пустым
-notified = False # Флаги для уведомлений
-is_fresh_start = True
-crashed = 0 # Сервер упал или ещё не запустился.
+@dataclass
+class WatchdogState:
+    empty_since: Optional[float] = None  # Когда сервер стал пустым
+    notified: bool = False  # Флаги для уведомлений
+    is_fresh_start: bool = True
+    crashed: int = 0  # Сервер упал или ещё не запустился.
+
+    def reset(self):
+        for f in fields(self):
+            setattr(self, f.name, f.default)
+
+watchdog_state = WatchdogState()
+
+
+def reset_watchdog_state():
+    watchdog_state.reset()
 
 
 async def watchdog_tick(shutdown_callback, notify_callback=None):
     logger.debug("Watchdog tick.")
-    global empty_since, notified, is_fresh_start, crashed
     players = await check_server_players(SERVER_ADDRESS, QUERY_PORT)
     now = time.time()
 
     if players is not None:
-        crashed = 0
-        if is_fresh_start:
+        watchdog_state.crashed = 0
+        if watchdog_state.is_fresh_start:
             if notify_callback:
                 await notify_callback("✅ Minecraft сервер доступен для подключения.")
-            is_fresh_start = False
+            watchdog_state.is_fresh_start = False
 
     if players == 0:
-        if empty_since is None:
-            empty_since = now
+        if watchdog_state.empty_since is None:
+            watchdog_state.empty_since = now
             logger.info("Watchdog: server is empty, starting shutdown timer")
-        elif now - empty_since >= WD_POWEROFF_COOLDOWN:
+        elif now - watchdog_state.empty_since >= WD_POWEROFF_COOLDOWN:
             logger.warning("Watchdog: server remained empty, cooldown passed — shutting down VPS")
             if notify_callback:
                 await notify_callback(f"🔴 На сервере не было игроков больше {WD_POWEROFF_COOLDOWN // 60} минут."
                                       f" Сервер выключен.")
             await shutdown_callback()
-            empty_since = None  # Reset after shutdown
-            notified = False  # сбрасываем флаг после выключения
-            is_fresh_start = True # следующий запуск будет новым
+            watchdog_state.empty_since = None  # Reset after shutdown
+            watchdog_state.notified = False  # сбрасываем флаг после выключения
+            watchdog_state.is_fresh_start = True # следующий запуск будет новым
         else:
-            remaining = int(WD_POWEROFF_COOLDOWN - (now - empty_since))
+            remaining = int(WD_POWEROFF_COOLDOWN - (now - watchdog_state.empty_since))
             logger.info(f"Watchdog: server still empty, {remaining} seconds left until shutdown")
-            if notify_callback and not notified:
+            if notify_callback and not watchdog_state.notified:
                 await notify_callback(f"ℹ️ На сервере нет игроков. "
                                       f"Сервер будет выключен через {WD_POWEROFF_COOLDOWN // 60} минут.")
-                notified = True  # для однократного вывода
+                watchdog_state.notified = True  # для однократного вывода
 
     elif players is not None:
-        if empty_since is not None:
+        if watchdog_state.empty_since is not None:
             logger.info("Watchdog: players joined — resetting shutdown timer")
-            empty_since = None  # Reset timer because players are online
-            notified = False
+            watchdog_state.empty_since = None  # Reset timer because players are online
+            watchdog_state.notified = False
     else: # случай с падением minecraft или первым запуском.
-        if not is_fresh_start:
+        if not watchdog_state.is_fresh_start:
             logger.warning("Watchdog: looks like minecraft server is crashed or unreachable.")
         else:
             logger.info("Watchdog: Minecraft server is offline and probably starting.")
-        if notify_callback and crashed > 1 and not is_fresh_start:
+        if notify_callback and watchdog_state.crashed > 1 and not watchdog_state.is_fresh_start:
             await notify_callback("⚠️ Minecraft сервер временно недоступен или аварийно завершил работу.")
-            notified = False
-            is_fresh_start = True # для вывода уведомления о запуске
-        elif notify_callback and crashed == 0 and is_fresh_start:
+            watchdog_state.notified = False
+            watchdog_state.is_fresh_start = True # для вывода уведомления о запуске
+        elif notify_callback and watchdog_state.crashed == 0 and watchdog_state.is_fresh_start:
             await notify_callback("⏳ Minecraft сервер запускается...")
-        crashed += 1
-        empty_since = None #  сброс таймера до корректного восстановления работы
+        watchdog_state.crashed += 1
+        watchdog_state.empty_since = None #  сброс таймера до корректного восстановления работы


### PR DESCRIPTION
Что сделано:
- Переписана логика хранения состояния watchdog. Глобальные переменные состояния заменены на датакласс.
- Добавлена функция сброса состояния watchdog, вызываемая при выключении сервера.
- Переписаны юнит-тесты для проверки логики работы watchdog.

Проверка работоспособности;
1. Выключить запущенный сервер через команду /poweroff.
2. Убедиться в отсутствии уведомления о краше сервера.

Fixes #4