### PR TITLE
Refactor: improve watchdog and minecraft server state handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,13 +3,13 @@ import json
 import random
 import os
 from functools import wraps
-
 import aiohttp
 import time
 from dotenv import load_dotenv
 from telegram import Update
 from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes, MessageHandler, filters, Job, JobQueue
-from watchdog import watchdog_tick, get_players_list, reset_watchdog_state
+from watchdog import watchdog_tick, reset_watchdog_state
+from minecraft_server import mc_server
 from typing import Optional
 
 # Enable logging
@@ -60,11 +60,23 @@ def check_maintenance(func):
         return await func(update, context)
     return wrapper
 
+def check_permissions(func):
+    """Декоратор проверки прав доступа"""
+    @wraps(func)
+    async def wrapper(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        if not is_authorized(update.effective_chat.id):
+            await update.message.reply_text("⛔ Недостаточно прав для выполнения команды.")
+            return None
+        return await func(update, context)
+    return wrapper
+
 # Время последнего успешного запуска VPS (в секундах с эпохи)
 last_poweron_time = 0
 last_poweroff_time = 0
 # Время последнего запроса статуса сервера
 last_status_time = 0
+# Кэшированный статус Minecraft-сервера
+mc_server.online = False
 POWERON_COOLDOWN = 20 * 60  # 20 минут в секундах
 POWEROFF_COOLDOWN = 1 * 60 # 1 минута
 STATUS_COOLDOWN = 5  # запрос статуса
@@ -177,9 +189,10 @@ def watchdog_stop():
         logger.info("Removed watchdog job")
 
 async def shutdown_vps():
-    now = time.time()
-    active_chats.clear() # сброс активных чатов для уведомлений после выключения сервера
     global last_poweron_time, watchdog_job
+    now = time.time()
+    mc_server.online = False # Minecraft сервер неактивен при полном выключении VPS
+    active_chats.clear() # сброс активных чатов для уведомлений после выключения сервера
     last_poweron_time = now  # предотвращение быстрого запуска VPS после включения
     # после выключения VPS сбрасываем задачу и состояние watchdog
     watchdog_stop()
@@ -372,14 +385,11 @@ async def list_authorized(update: Update, context: ContextTypes.DEFAULT_TYPE): #
 
 
 @check_maintenance
+@check_permissions
 @log_command("/poweron")
 async def poweron(update: Update, context: ContextTypes.DEFAULT_TYPE): # type: ignore
     global last_poweron_time, last_status_time, active_chats
     now = time.time()
-
-    if not is_authorized(update.effective_chat.id):
-        await update.message.reply_text("⛔ Недостаточно прав для выполнения команды.")
-        return
 
     if len(context.args) == 1 and context.args[0] == "force": # type: ignore
         if update.effective_user.id != ADMIN_CHAT_ID:
@@ -512,13 +522,10 @@ async def poweroff(update: Update, context: ContextTypes.DEFAULT_TYPE): # type: 
 
 
 @check_maintenance
+@check_permissions
 @log_command("/status")
 async def status(update: Update, context: ContextTypes.DEFAULT_TYPE): # type: ignore
     global last_status_time
-
-    if not is_authorized(update.effective_chat.id):
-        await update.message.reply_text("⛔ Недостаточно прав для выполнения команды.")
-        return
 
     now = time.time()
     if now - last_status_time < STATUS_COOLDOWN:
@@ -538,14 +545,15 @@ async def status(update: Update, context: ContextTypes.DEFAULT_TYPE): # type: ig
         is_power_on = server_status.get("IsPowerOn")
         if is_power_on and not context.chat_data.get("muted", False):
             active_chats.add(update.effective_chat.id) # добавляем чат для уведомлений только если сервер активен
-            players = await get_players_list()
-            if players is not None:
-                await update.message.reply_text(f"🟢 Сервер включен. На сервере {players} игрок(ов).")
+            if mc_server.online:
+                await update.message.reply_text(f"🟢 Сервер включен. На сервере {mc_server.players_online} игрок(ов).")
                 watchdog_run()
             else:
                 await update.message.reply_text("🟡 Linux cервер включен. Minecraft сервер не запущен.")
+                mc_server.online = False
         elif is_power_on is False:
             await update.message.reply_text("🔴 Сервер выключен.")
+            mc_server.online = False
             watchdog_stop()
         else:
             await update.message.reply_text("❓ Не удалось определить состояние сервера.")
@@ -570,11 +578,9 @@ async def maintenance(update: Update, context: ContextTypes.DEFAULT_TYPE): # typ
     else:
         await update.message.reply_text("🎮 Режим обслуживания выключен.")
 
+@check_permissions
 @log_command("/mute")
 async def mute(update: Update, context: ContextTypes.DEFAULT_TYPE): # type: ignore
-    if not is_authorized(update.effective_chat.id):
-        await update.message.reply_text("⛔ Недостаточно прав для выполнения команды.")
-        return
 
     is_muted = context.chat_data.get("muted", False)
     context.chat_data["muted"] = not is_muted
@@ -586,6 +592,15 @@ async def mute(update: Update, context: ContextTypes.DEFAULT_TYPE): # type: igno
         active_chats.add(update.effective_chat.id)
         await update.message.reply_text("🔔 Уведомления включены.")
 
+
+@check_permissions
+@log_command("/version")
+async def get_cached_mc_version(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Хендлер вывода текущей версии Minecraft сервера без запроса к API"""
+    if mc_server.version:
+        await update.message.reply_text(f"ℹ️ Версия Minecraft сервера: {mc_server.version_number}")
+    else:
+        await update.message.reply_text("ℹ️ Версия Minecraft сервера неизвестна.")
 
 
 if __name__ == "__main__":
@@ -603,6 +618,7 @@ if __name__ == "__main__":
     application.add_handler(CommandHandler("authorized", list_authorized))
     application.add_handler(CommandHandler("maintain", maintenance))
     application.add_handler(CommandHandler("mute", mute))
+    application.add_handler(CommandHandler("version", get_cached_mc_version))
     application.add_handler(MessageHandler(filters.ALL & ~filters.COMMAND, echo))
     #application.add_handler(MessageHandler(filters.ALL, log_all), group=0) # для логирования всего
     application.run_polling(poll_interval=1, timeout=30)

--- a/minecraft_server.py
+++ b/minecraft_server.py
@@ -1,0 +1,17 @@
+import os
+from dataclasses import dataclass
+
+@dataclass
+class MinecraftServer:
+    server_address: str = os.getenv("SERVER_ADDRESS")  # или IP
+    query_port: int = 25565
+    check_interval: int = 60  # секунд между проверками
+    wd_poweroff_cooldown: int = 10 * 60  # 10 минут
+    version: str = ""
+    version_number: str = ""
+    # runtime state
+    online: bool = False
+    players_online: int | None  = None
+    last_check: float | None = None # Пока не используется
+
+mc_server = MinecraftServer() # Общий shared instance Minecraft сервера

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -6,13 +6,15 @@ from watchdog import watchdog_tick, mc_server, watchdog_state
 async def test_online_with_players(monkeypatch):
     state = {"notified": False, "shutdown": False}
 
-    async def check_server_players():
-        return 3  # игроки есть
+    # игроки есть
+    async def mock_get_server_status():
+        mc_server.online = True
+        mc_server.players_online = 3
 
     async def notify_cb(msg): state["notified"] = msg
     async def shutdown_cb(): state["shutdown"] = True
 
-    monkeypatch.setattr("watchdog.check_server_players", check_server_players)
+    monkeypatch.setattr("watchdog.get_server_status", mock_get_server_status)
 
     # Сбрасываем состояние датакласса перед тестом
     watchdog_state.reset()
@@ -27,13 +29,14 @@ async def test_online_with_players(monkeypatch):
 async def test_empty_server_timer_not_expired(monkeypatch):
     state = {"notified": None, "shutdown": False}
 
-    async def check_server_players():
-        return 0
+    async def mock_get_server_status():
+        mc_server.online = True
+        mc_server.players_online = 0
 
     async def notify_cb(msg): state["notified"] = msg
     async def shutdown_cb(): state["shutdown"] = True
 
-    monkeypatch.setattr("watchdog.check_server_players", check_server_players)
+    monkeypatch.setattr("watchdog.get_server_status", mock_get_server_status)
 
     # Подготавливаем состояние датакласса
     watchdog_state.reset()
@@ -50,13 +53,14 @@ async def test_empty_server_timer_not_expired(monkeypatch):
 async def test_empty_server_shutdown(monkeypatch):
     state = {"notified": None, "shutdown": False}
 
-    async def check_server_players():
-        return 0
+    async def mock_get_server_status():
+        mc_server.online = True
+        mc_server.players_online = 0
 
     async def notify_cb(msg): state["notified"] = msg
     async def shutdown_cb(): state["shutdown"] = True
 
-    monkeypatch.setattr("watchdog.check_server_players", check_server_players)
+    monkeypatch.setattr("watchdog.get_server_status", mock_get_server_status)
 
     watchdog_state.reset()
     watchdog_state.empty_since = time.time() - mc_server.wd_poweroff_cooldown - 5
@@ -73,13 +77,15 @@ async def test_server_crashed(monkeypatch):
     state = {"notified": None, "shutdown": False}
     crashes = {"count": 2}
 
-    async def check_server_players():
-        return None  # сервер упал
+    # сервер упал
+    async def mock_get_server_status():
+        mc_server.online = False
+        mc_server.players_online = None
 
     async def notify_cb(msg): state["notified"] = msg
     async def shutdown_cb(): state["shutdown"] = True
 
-    monkeypatch.setattr("watchdog.check_server_players", check_server_players)
+    monkeypatch.setattr("watchdog.get_server_status", mock_get_server_status)
 
     watchdog_state.reset()
     watchdog_state.crashed = crashes["count"]
@@ -94,13 +100,16 @@ async def test_server_crashed(monkeypatch):
 async def test_first_start(monkeypatch):
     state = {"notified": None, "shutdown": False}
 
-    async def check_server_players():
-        return None  # сервер недоступен, первый запуск
+    # сервер недоступен, первый запуск
+    async def mock_get_server_status():
+        mc_server.online = False
+        mc_server.players_online = None
+
 
     async def notify_cb(msg): state["notified"] = msg
     async def shutdown_cb(): state["shutdown"] = True
 
-    monkeypatch.setattr("watchdog.check_server_players", check_server_players)
+    monkeypatch.setattr("watchdog.get_server_status", mock_get_server_status)
 
     watchdog_state.reset()
     watchdog_state.crashed = 0

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,6 +1,6 @@
 import pytest
 import time
-from watchdog import watchdog_tick, MINECRAFT_SERVER, WATCHDOG_STATE
+from watchdog import watchdog_tick, mc_server, watchdog_state
 
 @pytest.mark.asyncio
 async def test_online_with_players(monkeypatch):
@@ -15,8 +15,8 @@ async def test_online_with_players(monkeypatch):
     monkeypatch.setattr("watchdog.check_server_players", check_server_players)
 
     # Сбрасываем состояние датакласса перед тестом
-    WATCHDOG_STATE.reset()
-    WATCHDOG_STATE.is_fresh_start = True
+    watchdog_state.reset()
+    watchdog_state.is_fresh_start = True
 
     await watchdog_tick(shutdown_cb, notify_cb)
     assert "✅ Minecraft сервер доступен" in state["notified"]
@@ -36,10 +36,10 @@ async def test_empty_server_timer_not_expired(monkeypatch):
     monkeypatch.setattr("watchdog.check_server_players", check_server_players)
 
     # Подготавливаем состояние датакласса
-    WATCHDOG_STATE.reset()
-    WATCHDOG_STATE.empty_since = time.time() - 100
-    WATCHDOG_STATE.is_fresh_start = False
-    WATCHDOG_STATE.notified = False
+    watchdog_state.reset()
+    watchdog_state.empty_since = time.time() - 100
+    watchdog_state.is_fresh_start = False
+    watchdog_state.notified = False
 
     await watchdog_tick(shutdown_cb, notify_cb)
     assert "нет игроков" in state["notified"]
@@ -58,10 +58,10 @@ async def test_empty_server_shutdown(monkeypatch):
 
     monkeypatch.setattr("watchdog.check_server_players", check_server_players)
 
-    WATCHDOG_STATE.reset()
-    WATCHDOG_STATE.empty_since = time.time() - MINECRAFT_SERVER.wd_poweroff_cooldown - 5
-    WATCHDOG_STATE.is_fresh_start = False
-    WATCHDOG_STATE.notified = False
+    watchdog_state.reset()
+    watchdog_state.empty_since = time.time() - mc_server.wd_poweroff_cooldown - 5
+    watchdog_state.is_fresh_start = False
+    watchdog_state.notified = False
 
     await watchdog_tick(shutdown_cb, notify_cb)
     assert "выключен" in state["notified"]
@@ -81,10 +81,10 @@ async def test_server_crashed(monkeypatch):
 
     monkeypatch.setattr("watchdog.check_server_players", check_server_players)
 
-    WATCHDOG_STATE.reset()
-    WATCHDOG_STATE.crashed = crashes["count"]
-    WATCHDOG_STATE.is_fresh_start = False
-    WATCHDOG_STATE.notified = False
+    watchdog_state.reset()
+    watchdog_state.crashed = crashes["count"]
+    watchdog_state.is_fresh_start = False
+    watchdog_state.notified = False
 
     await watchdog_tick(shutdown_cb, notify_cb)
     assert "временно недоступен" in state["notified"]
@@ -102,10 +102,10 @@ async def test_first_start(monkeypatch):
 
     monkeypatch.setattr("watchdog.check_server_players", check_server_players)
 
-    WATCHDOG_STATE.reset()
-    WATCHDOG_STATE.crashed = 0
-    WATCHDOG_STATE.is_fresh_start = True
-    WATCHDOG_STATE.notified = False
+    watchdog_state.reset()
+    watchdog_state.crashed = 0
+    watchdog_state.is_fresh_start = True
+    watchdog_state.notified = False
 
     await watchdog_tick(shutdown_cb, notify_cb)
     assert "запускается" in state["notified"]
@@ -132,10 +132,10 @@ async def test_failed_server_status(monkeypatch):
     monkeypatch.setattr("watchdog.fast_check", mock_fast_check)
     monkeypatch.setattr("watchdog.JavaServer.async_lookup", mock_lookup)
 
-    WATCHDOG_STATE.reset()
-    WATCHDOG_STATE.crashed = crashes["count"]
-    WATCHDOG_STATE.is_fresh_start = False
-    WATCHDOG_STATE.notified = False
+    watchdog_state.reset()
+    watchdog_state.crashed = crashes["count"]
+    watchdog_state.is_fresh_start = False
+    watchdog_state.notified = False
 
     await watchdog_tick(shutdown_cb, notify_cb)
     assert state["notified"] is None

--- a/watchdog.py
+++ b/watchdog.py
@@ -1,27 +1,13 @@
 import asyncio
 import logging
 import time
-import os
 from dotenv import load_dotenv
 from mcstatus import JavaServer
 from re import search
-from typing import Optional
 from dataclasses import dataclass, fields
+from minecraft_server import mc_server
 
 load_dotenv()
-
-@dataclass
-class MinecraftServer:
-    server_address: str = os.getenv("SERVER_ADDRESS")  # или IP
-    query_port: int = 25565
-    check_interval: int = 60  # секунд между проверками
-    wd_poweroff_cooldown: int = 10 * 60  # 10 минут
-    version: str = ""
-    version_number: str = ""
-
-MINECRAFT_SERVER = MinecraftServer()
-
-
 logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(message)s",
     level=logging.INFO
@@ -31,8 +17,6 @@ logging.basicConfig(
 logger = logging.getLogger("watchdog")
 logger.setLevel(logging.INFO)
 
-async def get_players_list():
-    return await check_server_players()
 
 
 async def fast_check(host: str, port: int, timeout: float = 2.0):
@@ -52,8 +36,8 @@ async def fast_check(host: str, port: int, timeout: float = 2.0):
         logger.exception(f"Watchdog: port fast check — unknown exception: {e}")
         return None
 
-async def get_server_status(server_address: str = MINECRAFT_SERVER.server_address,
-                            port: int = MINECRAFT_SERVER.query_port):
+async def get_server_status(server_address: str = mc_server.server_address,
+                            port: int = mc_server.query_port):
     is_open = await fast_check(server_address, port, timeout=2)
     if is_open:
         try:
@@ -61,34 +45,31 @@ async def get_server_status(server_address: str = MINECRAFT_SERVER.server_addres
             server = await JavaServer.async_lookup(f"{server_address}:{port}", timeout=3)
             logger.debug("Watchdog: mcstatus trying async_status...")
             status = await asyncio.wait_for(server.async_status(), timeout=6)
-            logger.debug(f"Watchdog: ONLINE Successfully get Minecraft server status.")
-            if not MINECRAFT_SERVER.version:
-                MINECRAFT_SERVER.version = status.version.name
-                MINECRAFT_SERVER.version_number = (search(r"([0-9]+(\.[0-9]+)+)",
-                           MINECRAFT_SERVER.version)).group(1)
-            return status
+            logger.debug("Watchdog: ONLINE Successfully get Minecraft server status.")
+            if status:
+                mc_server.players_online = status.players.online  # Запись в глобальный инстанс
+                logger.debug(f"Watchdog: ONLINE {mc_server.players_online} players online.")
+                mc_server.online = True
+                if not mc_server.version:
+                    mc_server.version = status.version.name
+                    mc_server.version_number = (search(r"([0-9]+(\.[0-9]+)+)",
+                                                       mc_server.version)).group(1)
+            else:
+                logger.debug(f"Watchdog: OFFLINE Failed to get list of players online.")
+                mc_server.online = False
+                mc_server.players_online = None
 
         except Exception as e:
+            mc_server.online = False
+            mc_server.players_online = None
             logger.debug(f"Watchdog: OFFLINE Minecraft server unreachable. {type(e).__name__}: {e}")
-            return None
     else:
-        return None
-
-async def check_server_players():
-    status = await get_server_status()
-    if status:
-        # noinspection PyUnresolvedReferences
-        # для подавления warning в pycharm
-        players_online = status.players.online
-        logger.debug(f"Watchdog: ONLINE {players_online} players online.")
-        return players_online
-    else:
-        logger.debug(f"Watchdog: OFFLINE Failed to get list of players online.")
-        return None
+        mc_server.online = False
+        mc_server.players_online = None
 
 @dataclass
 class WatchdogState:
-    empty_since: Optional[float] = None  # Когда сервер стал пустым
+    empty_since: float | None = None  # Когда сервер стал пустым
     notified: bool = False  # Флаги для уведомлений
     is_fresh_start: bool = True
     crashed: int = 0  # Сервер упал или ещё не запустился.
@@ -97,64 +78,64 @@ class WatchdogState:
         for f in fields(self):
             setattr(self, f.name, f.default)
 
-WATCHDOG_STATE = WatchdogState()
+watchdog_state = WatchdogState()
 
 
 def reset_watchdog_state():
-    WATCHDOG_STATE.reset()
+    watchdog_state.reset()
 
 
 async def watchdog_tick(shutdown_callback, notify_callback=None):
     logger.debug("Watchdog tick.")
-    players = await check_server_players()
+    await get_server_status()
     now = time.time()
 
-    if players is not None:
-        WATCHDOG_STATE.crashed = 0
-        if WATCHDOG_STATE.is_fresh_start:
+    if mc_server.online:
+        watchdog_state.crashed = 0
+        if watchdog_state.is_fresh_start:
             if notify_callback:
                 await notify_callback(f"✅ Minecraft сервер доступен для подключения."
-                                      f"\nВерсия сервера: {MINECRAFT_SERVER.version_number}")
-            WATCHDOG_STATE.is_fresh_start = False
+                                      f"\nВерсия сервера: {mc_server.version_number}")
+            watchdog_state.is_fresh_start = False
 
-    if players == 0:
-        if WATCHDOG_STATE.empty_since is None:
-            WATCHDOG_STATE.empty_since = now
+    if mc_server.players_online == 0:
+        if watchdog_state.empty_since is None:
+            watchdog_state.empty_since = now
             logger.info("Watchdog: server is empty, starting shutdown timer")
-        elif now - WATCHDOG_STATE.empty_since >= MINECRAFT_SERVER.wd_poweroff_cooldown:
+        elif now - watchdog_state.empty_since >= mc_server.wd_poweroff_cooldown:
             logger.warning("Watchdog: server remained empty, cooldown passed — shutting down VPS")
             if notify_callback:
                 await notify_callback(f"🔴 На сервере не было игроков больше "
-                                      f"{MINECRAFT_SERVER.wd_poweroff_cooldown // 60} минут."
+                                      f"{mc_server.wd_poweroff_cooldown // 60} минут."
                                       f" Сервер выключен.")
             await shutdown_callback()
-            WATCHDOG_STATE.empty_since = None  # Reset after shutdown
-            WATCHDOG_STATE.notified = False  # сбрасываем флаг после выключения
-            WATCHDOG_STATE.is_fresh_start = True # следующий запуск будет новым
+            watchdog_state.empty_since = None  # Reset after shutdown
+            watchdog_state.notified = False  # сбрасываем флаг после выключения
+            watchdog_state.is_fresh_start = True # следующий запуск будет новым
         else:
-            remaining = int(MINECRAFT_SERVER.wd_poweroff_cooldown - (now - WATCHDOG_STATE.empty_since))
+            remaining = int(mc_server.wd_poweroff_cooldown - (now - watchdog_state.empty_since))
             logger.info(f"Watchdog: server still empty, {remaining} seconds left until shutdown")
-            if notify_callback and not WATCHDOG_STATE.notified:
+            if notify_callback and not watchdog_state.notified:
                 await notify_callback(f"ℹ️ На сервере нет игроков. "
                                       f"Сервер будет выключен через "
-                                      f"{MINECRAFT_SERVER.wd_poweroff_cooldown // 60} минут.")
-                WATCHDOG_STATE.notified = True  # для однократного вывода
+                                      f"{mc_server.wd_poweroff_cooldown // 60} минут.")
+                watchdog_state.notified = True  # для однократного вывода
 
-    elif players is not None:
-        if WATCHDOG_STATE.empty_since is not None:
+    elif mc_server.players_online is not None:
+        if watchdog_state.empty_since is not None:
             logger.info("Watchdog: players joined — resetting shutdown timer")
-            WATCHDOG_STATE.empty_since = None  # Reset timer because players are online
-            WATCHDOG_STATE.notified = False
+            watchdog_state.empty_since = None  # Reset timer because players are online
+            watchdog_state.notified = False
     else: # случай с падением minecraft или первым запуском.
-        if not WATCHDOG_STATE.is_fresh_start:
+        if not watchdog_state.is_fresh_start:
             logger.warning("Watchdog: looks like minecraft server is crashed or unreachable.")
         else:
             logger.info("Watchdog: Minecraft server is offline and probably starting.")
-        if notify_callback and WATCHDOG_STATE.crashed > 1 and not WATCHDOG_STATE.is_fresh_start:
+        if notify_callback and watchdog_state.crashed > 1 and not watchdog_state.is_fresh_start:
             await notify_callback("⚠️ Minecraft сервер временно недоступен или аварийно завершил работу.")
-            WATCHDOG_STATE.notified = False
-            WATCHDOG_STATE.is_fresh_start = True # для вывода уведомления о запуске
-        elif notify_callback and WATCHDOG_STATE.crashed == 0 and WATCHDOG_STATE.is_fresh_start:
+            watchdog_state.notified = False
+            watchdog_state.is_fresh_start = True # для вывода уведомления о запуске
+        elif notify_callback and watchdog_state.crashed == 0 and watchdog_state.is_fresh_start:
             await notify_callback("⏳ Minecraft сервер запускается...")
-        WATCHDOG_STATE.crashed += 1
-        WATCHDOG_STATE.empty_since = None #  сброс таймера до корректного восстановления работы
+        watchdog_state.crashed += 1
+        watchdog_state.empty_since = None #  сброс таймера до корректного восстановления работы


### PR DESCRIPTION
Выполнен рефакторинг логики watchdog и main.
Состояние Minecraft-сервера вынесено в отдельный dataclass.

### Основные изменения
1. Состояние Minecraft-сервера выделено в отдельный dataclass (mc_server)
2. Логика legacy-функций get_players_list() и check_server_players() объединена и перенесена в get_server_status()
3. get_server_status() теперь использует глобальный инстанс mc_server для кэширования состояния
4. Логика проверки прав доступа вынесена в декоратор check_permissions
5. Приведено именование глобальных инстансов к более корректному стилю
6. Обновлены юнит-тесты для watchdog

### Новая функциональность
1. Добавлен обработчик команды /version, который выводит кэшированную версию Minecraft-сервера без обращения к API