### PR TITLE
Add shutdown countdown to status response

### DIFF
--- a/main.py
+++ b/main.py
@@ -188,6 +188,9 @@ async def api_request(action: str):
 
 def watchdog_stop():
     global watchdog_job
+
+    mc_server.shutdown_remaining = None # Сброс runtime состояния minecraft сервера
+
     if watchdog_job is not None:
         watchdog_job.schedule_removal()
         watchdog_job = None
@@ -553,8 +556,22 @@ async def status(update: Update, context: ContextTypes.DEFAULT_TYPE):  # type: i
         if is_power_on and not context.chat_data.get("muted", False):
             active_chats.add(update.effective_chat.id) # добавляем чат для уведомлений только если сервер активен
             if mc_server.online:
-                await update.message.reply_text(f"🟢 Сервер включен. На сервере {mc_server.players_online} игрок(ов).")
                 watchdog_run()
+                message = (
+                    f"🟢 Сервер включен. "
+                    f"На сервере {mc_server.players_online} игрок(ов)."
+                )
+
+                if mc_server.players_online == 0:
+                    remaining = (
+                        f"{mc_server.shutdown_remaining} сек."
+                        if mc_server.shutdown_remaining < 60
+                        else f"{(mc_server.shutdown_remaining / 60):.0f} мин."
+                    )
+
+                    message += f"\n⏳ До автовыключения: {remaining}"
+
+                await update.message.reply_text(message)
             else:
                 await update.message.reply_text("🟡 Linux cервер включен. Minecraft сервер не запущен.")
                 mc_server.online = False

--- a/minecraft_server.py
+++ b/minecraft_server.py
@@ -13,5 +13,6 @@ class MinecraftServer:
     online: bool = False
     players_online: int | None  = None
     last_check: float | None = None # Пока не используется
+    shutdown_remaining: int | None = None # Осталось до перезапуска
 
 mc_server = MinecraftServer() # Общий shared instance Minecraft сервера

--- a/watchdog.py
+++ b/watchdog.py
@@ -112,9 +112,9 @@ async def watchdog_tick(shutdown_callback, notify_callback=None):
             watchdog_state.warning_3m_sent = False  # сбрасываем флаг после выключения
             watchdog_state.is_fresh_start = True # следующий запуск будет новым
         else:
-            remaining = int(mc_server.wd_poweroff_cooldown - (now - watchdog_state.empty_since))
-            logger.info(f"Watchdog: server still empty, {remaining} seconds left until shutdown")
-            if remaining <= 180 and notify_callback and not watchdog_state.warning_3m_sent:
+            mc_server.shutdown_remaining = int(mc_server.wd_poweroff_cooldown - (now - watchdog_state.empty_since))
+            logger.info(f"Watchdog: server still empty, {mc_server.shutdown_remaining} seconds left until shutdown")
+            if mc_server.shutdown_remaining <= 180 and notify_callback and not watchdog_state.warning_3m_sent:
                 await notify_callback(f"ℹ️ На сервере никого нет. До выключения осталось 3 минуты.")
                 watchdog_state.warning_3m_sent = True  # для однократного вывода
 


### PR DESCRIPTION
### Команда /status
- Улучшено отображение состояния сервера.
- При пустом сервере теперь выводится оставшееся время до автовыключения.