### PR TITLE
Fix runtime state reset after VPS shutdown

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ notify_logger = logging.getLogger("notify")
 logging.getLogger("notify").setLevel(logging.INFO)
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
 def log_command(command_name):
@@ -553,6 +554,10 @@ async def status(update: Update, context: ContextTypes.DEFAULT_TYPE):  # type: i
             return
         last_status_time = now  # обновляем время успешного запроса статуса
         is_power_on = server_status.get("IsPowerOn")
+        logger.debug(
+            f"IsPowerOn={is_power_on}, type={type(is_power_on)}"
+        )
+        logger.debug(f"server_status={server_status}")
         if is_power_on and not context.chat_data.get("muted", False):
             active_chats.add(update.effective_chat.id) # добавляем чат для уведомлений только если сервер активен
             watchdog_run()

--- a/main.py
+++ b/main.py
@@ -26,7 +26,7 @@ notify_logger = logging.getLogger("notify")
 logging.getLogger("notify").setLevel(logging.INFO)
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.INFO)
 
 
 def log_command(command_name):

--- a/main.py
+++ b/main.py
@@ -554,10 +554,14 @@ async def status(update: Update, context: ContextTypes.DEFAULT_TYPE):  # type: i
             return
         last_status_time = now  # обновляем время успешного запроса статуса
         is_power_on = server_status.get("IsPowerOn")
+        logger.debug(f"server_status={server_status}")
         logger.debug(
             f"IsPowerOn={is_power_on}, type={type(is_power_on)}"
         )
-        logger.debug(f"server_status={server_status}")
+        logger.debug(
+            f"mc_server.online={mc_server.online}, "
+            f"chat_muted={context.chat_data.get('muted', False)}"
+        )
         if is_power_on and not context.chat_data.get("muted", False):
             active_chats.add(update.effective_chat.id) # добавляем чат для уведомлений только если сервер активен
             watchdog_run()

--- a/main.py
+++ b/main.py
@@ -199,15 +199,21 @@ def watchdog_stop():
 
 
 async def shutdown_vps():
-    global last_poweron_time, watchdog_job
+    global last_poweron_time
     now = time.time()
-    mc_server.online = False  # Minecraft сервер неактивен при полном выключении VPS
-    active_chats.clear()  # сброс активных чатов для уведомлений после выключения сервера
+    result = await api_request("ShutDownGuestOS")
+    logger.debug(f"shutdown_vps_API_result = {result}")
+    if "error" in result:
+        return result  # ничего не трогаем
+    # считаем, что shutdown инициирован успешно
     last_poweron_time = now  # предотвращение быстрого запуска VPS после включения
     # после выключения VPS сбрасываем задачу и состояние watchdog
     watchdog_stop()
     reset_watchdog_state()
-    return await api_request("ShutDownGuestOS")
+    mc_server.reset_runtime()  # сброс runtime состояния MC сервера
+    active_chats.clear()  # сброс активных чатов для уведомлений после выключения сервера
+    logger.info("Shutdown VPS initiated successfully")
+    return result
 
 
 async def watchdog_task(context: ContextTypes.DEFAULT_TYPE):  # type: ignore # Стандартная сигнатура для job_queue

--- a/minecraft_server.py
+++ b/minecraft_server.py
@@ -15,4 +15,10 @@ class MinecraftServer:
     last_check: float | None = None # Пока не используется
     shutdown_remaining: int | None = None # Осталось до перезапуска
 
+    def reset_runtime(self):
+        self.online = False
+        self.players_online = None
+        self.shutdown_remaining = None
+        self.last_check = None
+
 mc_server = MinecraftServer() # Общий shared instance Minecraft сервера


### PR DESCRIPTION
Что изменено:
- Добавлен метод reset_runtime() для MinecraftServer
- Runtime-состояние сбрасывается после успешного запроса ShutDownGuestOS
- Добавлено дополнительное логирование shutdown API

Причина:
После последовательности
/poweron -> /poweroff -> /poweron force -> /status

наблюдалось неконсистентное состояние mc_server.
Предположительно причиной было отсутствие сброса runtime-состояния после выключения VPS.

Статус:
Баг не воспроизводится в production.

Fixes #30