### PR TITLE
Bugfix mute command

### DIFF
--- a/handlers/handlers.py
+++ b/handlers/handlers.py
@@ -396,8 +396,10 @@ async def status(update: Update, context: ContextTypes.DEFAULT_TYPE):
             f"mc_server.online={mc_server.online}, "
             f"chat_muted={context.chat_data.get('muted', False)}"
         )
-        if is_power_on and not context.chat_data.get("muted", False):
-            bot_state.active_chats.add(update.effective_chat.id) # добавляем чат для уведомлений только если сервер активен
+        if is_power_on:
+            if not context.chat_data.get("muted", False):
+                # добавляем чат для уведомлений только если сервер активен
+                bot_state.active_chats.add(update.effective_chat.id)
             job_queue = context.job_queue
             if job_queue is None:
                 raise RuntimeError("JobQueue is not available")

--- a/handlers/handlers.py
+++ b/handlers/handlers.py
@@ -344,7 +344,7 @@ async def poweroff(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
         elif is_power_on:
             # Отправка запроса на выключение
-            result = await watchdog.shutdown_all()
+            result = await bot_service.shutdown_all(context.application)
             if "error" in result:
                 await update.message.reply_text(f"⚠️ Ошибка: {result['error']}")
                 return

--- a/services/bot_service.py
+++ b/services/bot_service.py
@@ -74,12 +74,14 @@ async def log_all(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 def reset_chat_state(application: Application):
+    """Сбрасывает статус muted для всех чатов"""
     for chat_id, chat_data in application.chat_data.items():
         if chat_data.pop("muted", None) is not None:
             logger.debug(f"Successfully reset muted state for chat {chat_id}")
 
 
-async def shutdown_all(chat_state: Application):
+async def shutdown_all(application: Application):
+    """Полное выключение: VPS + watchdog + сброс состояния"""
     result = await vps_service.shutdown_vps()
     if "error" in result:
         logger.error(f"Failed to shutdown VPS: {result['error']}")
@@ -88,6 +90,6 @@ async def shutdown_all(chat_state: Application):
     watchdog.reset_watchdog_state()
     minecraft_server.mc_server.reset_runtime()
     tg_bot_state.bot_state.active_chats.clear()
-    reset_chat_state(chat_state)
+    reset_chat_state(application)
     logger.info("VPS and watchdog shutdown initiated successfully")
     return result

--- a/services/bot_service.py
+++ b/services/bot_service.py
@@ -1,11 +1,14 @@
 from functools import wraps
-from telegram.ext import ContextTypes
+from telegram.ext import ContextTypes, Application
 from config.config import bot_config
 import json
 import logging
 from telegram import Update
+from services import vps_service, watchdog
+from state import minecraft_server, bot_state as tg_bot_state
 
 logger = logging.getLogger(__name__)
+
 
 def log_command(command_name):
     def decorator(func):
@@ -17,6 +20,7 @@ def log_command(command_name):
         return wrapper
 
     return decorator
+
 
 def load_auth_data():
     try:
@@ -67,3 +71,23 @@ async def log_all(update: Update, context: ContextTypes.DEFAULT_TYPE):
     message = update.message
     if message:
         logger.info(f"[{user_name}] написал: {message.text or '[нет текста]'}")
+
+
+def reset_chat_state(application: Application):
+    for chat_id, chat_data in application.chat_data.items():
+        if chat_data.pop("muted", None) is not None:
+            logger.debug(f"Successfully reset muted state for chat {chat_id}")
+
+
+async def shutdown_all(chat_state: Application):
+    result = await vps_service.shutdown_vps()
+    if "error" in result:
+        logger.error(f"Failed to shutdown VPS: {result['error']}")
+        return result
+    watchdog.watchdog_stop()
+    watchdog.reset_watchdog_state()
+    minecraft_server.mc_server.reset_runtime()
+    tg_bot_state.bot_state.active_chats.clear()
+    reset_chat_state(chat_state)
+    logger.info("VPS and watchdog shutdown initiated successfully")
+    return result

--- a/services/watchdog.py
+++ b/services/watchdog.py
@@ -6,7 +6,7 @@ from mcstatus import JavaServer
 from re import search
 from dataclasses import dataclass, fields
 from telegram.ext import Job, JobQueue, ContextTypes
-from services import vps_service
+from services import bot_service
 from state.minecraft_server import mc_server
 from state.bot_state import bot_state
 
@@ -85,18 +85,6 @@ def watchdog_stop():
         watchdog_state.watchdog_job = None
         logger.info("Removed watchdog job")
 
-async def shutdown_all():
-    result = await vps_service.shutdown_vps()
-    if "error" in result:
-        logger.error(f"Failed to shutdown VPS: {result['error']}")
-        return result
-    watchdog_stop()
-    reset_watchdog_state()
-    mc_server.reset_runtime()
-    bot_state.active_chats.clear()
-    logger.info("VPS and watchdog shutdown initiated successfully")
-    return result
-
 async def watchdog_task(context: ContextTypes.DEFAULT_TYPE):
     async def notifier(message: str):
         if not bot_state.active_chats:
@@ -114,7 +102,11 @@ async def watchdog_task(context: ContextTypes.DEFAULT_TYPE):
                     f"Failed to send notification "
                     f"to {chat_id}: {e}"
                 )
-    await watchdog_tick(shutdown_all, notifier)
+
+    async def shutdown_bot():
+        await bot_service.shutdown_all(context.application)
+
+    await watchdog_tick(shutdown_bot, notifier)
 
 def watchdog_run(job_queue: JobQueue):
     if watchdog_state.watchdog_job is None and not bot_state.maintenance_mode:


### PR DESCRIPTION
При выключении сервера чат оставался в статусе "muted" (отключены уведомления), 
что означает, что в следующий раз при включении сервера пользователи не будут получать уведомления.

## Решение
- Перемещена функция `shutdown_all()` из `watchdog.py` в `bot_service.py`
- Добавлена функция `reset_chat_state()` для очистки статуса muted при выключении
- Улучшена логика обработки уведомлений в `status()` handler'е
- Исправлены циклические зависимости между модулями